### PR TITLE
Add getModels and count method to StackedLegend

### DIFF
--- a/src/geo/ui/legend.js
+++ b/src/geo/ui/legend.js
@@ -886,6 +886,14 @@ cdb.geo.ui.StackedLegend = cdb.core.View.extend({
 
   addTo: function(element) {
     $(element).html(this.render().$el);
+  },
+
+  count: function () {
+    return this.options.legends.length;
+  },
+
+  getModels: function () {
+    return this.options.legends;
   }
 });
 


### PR DESCRIPTION
Exposes two additional helper methods so we don't have to access `stackedLegend._models` directly in client code.